### PR TITLE
Remove Rinku rails helper

### DIFF
--- a/app/helpers/audits1984/application_helper.rb
+++ b/app/helpers/audits1984/application_helper.rb
@@ -1,5 +1,4 @@
 require "rouge"
-require "rails_rinku"
 
 module Audits1984
   module ApplicationHelper

--- a/app/views/audits1984/sessions/_executed_code.html.erb
+++ b/app/views/audits1984/sessions/_executed_code.html.erb
@@ -9,7 +9,7 @@
         <div class="media-content">
           <% if sensitive_access %>
             <p class="title is-4">Sensitive access *</p>
-            <p class="subtitle is-6"><%= auto_link(sensitive_access.justification) %></p>
+            <p class="subtitle is-6"><%= Rinku.auto_link(sensitive_access.justification).html_safe %></p>
           <% else %>
             <p class="title is-4">Protected access</p>
           <% end %>

--- a/app/views/audits1984/sessions/_header.html.erb
+++ b/app/views/audits1984/sessions/_header.html.erb
@@ -1,4 +1,4 @@
-<h2 class="title"><%= auto_link(session.reason) %> <%= sensitive_session_decoration(session) %></h2>
+<h2 class="title"><%= Rinku.auto_link(session.reason).html_safe %> <%= sensitive_session_decoration(session) %></h2>
 <h3 class="subtitle">by <%= session.user.username %>
   <br> <%= format_date_and_time(session.created_at) %></h3>
 

--- a/lib/audits1984/engine.rb
+++ b/lib/audits1984/engine.rb
@@ -1,4 +1,5 @@
 require "console1984"
+require 'rinku'
 
 module Audits1984
   class Engine < ::Rails::Engine


### PR DESCRIPTION
This will use the namespaced `Rinku.auto_link` helper instead. This way, it won't interfere with any auto_link helper used
by the host apps.
