### PR TITLE
Add configuration option for auditor method name attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,5 +60,5 @@ These config options are namespaced in `config.audits1984`:
 | Name                  | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
 | auditor_class         | The name of the auditor class. By default it's `::User.`     |
+| auditor_name_attribute | The attribute on the auditor class that returns the auditor's name. By default it's `:name`. |
 | base_controller_class | The host application base class that will be the parent of `audit1984` controllers. By default it's `::ApplicationController`. |
-

--- a/app/helpers/audits1984/application_helper.rb
+++ b/app/helpers/audits1984/application_helper.rb
@@ -2,6 +2,14 @@ require "rouge"
 
 module Audits1984
   module ApplicationHelper
+    def get_auditor_name(auditor)
+      if auditor == Audits1984::Current.auditor
+        "You"
+      else
+        auditor.public_send(Audits1984.auditor_name_attribute)
+      end
+    end
+
     def format_date(date)
       # <time datetime="2016-1-1">11:09 PM - 1 Jan 2016</time>
       date.strftime("%Y-%m-%d")

--- a/app/views/audits1984/sessions/_header.html.erb
+++ b/app/views/audits1984/sessions/_header.html.erb
@@ -6,7 +6,7 @@
   <ul class="mb-6">
     <% session.audits.except(&:new_record?).each do |audit| %>
       <li> <%= audit.status.humanize %>
-        by <%= audit.auditor == Audits1984::Current.auditor ? "You" : audit.auditor.name %>
+        by <%= get_auditor_name(audit.auditor) %>
         on <%= format_date_and_time(audit.created_at) %>
       </li>
     <% end %>

--- a/lib/audits1984.rb
+++ b/lib/audits1984.rb
@@ -7,5 +7,6 @@ loader.setup
 
 module Audits1984
   mattr_accessor :auditor_class, default: "::User"
+  mattr_accessor :auditor_name_attribute, default: :name
   mattr_accessor :base_controller_class, default: "::ApplicationController"
 end


### PR DESCRIPTION
Adds a new configuration option `auditor_name_attr` that accepts a `Symbol` containing the name of the attribute on the auditor class that returns the auditor's name to display in the UI.

Use case: our `User` record does not have a `name` field. We could define a `name` method on our `User` model class, but having to define a custom method on a class in our app for the sake of a third-party gem is a bit annoying. Instead, with this change, we can do:
```ruby
config.audits1984.auditor_name_attr = :email
```

I've tested this change in our app and verified that it works as expected.

cc @jorgemanrubia
