### PR TITLE
Add nonce to script tag

### DIFF
--- a/app/views/layouts/audits1984/application.html.erb
+++ b/app/views/layouts/audits1984/application.html.erb
@@ -8,7 +8,7 @@
 
   <%= csrf_meta_tags %>
 
-  <%= javascript_include_tag "audits1984/application", data: { turbo_track: :reload } %>
+  <%= javascript_include_tag "audits1984/application", nonce: true, data: { turbo_track: :reload } %>
   <%= stylesheet_link_tag "audits1984/application", media: :all, data: { turbo_track: :reload } %>
 </head>
 


### PR DESCRIPTION
Add `nonce: true` to `javascript_include_tag` directive.

When using a Content Security Policy like `script-src: strict-dynamic`, Audits1984's script will fail to load unless a nonce is used.

This does nothing when the app does not have a CSP and so should be safe for everyone.