### PR TITLE
Add pending only filter

### DIFF
--- a/app/controllers/audits1984/filtered_sessions_controller.rb
+++ b/app/controllers/audits1984/filtered_sessions_controller.rb
@@ -9,7 +9,7 @@ module Audits1984
 
     private
       def filtered_sessions_param
-        params.require(:filtered_sessions).permit(:sensitive_only, :from_date, :to_date)
+        params.require(:filtered_sessions).permit(:sensitive_only, :from_date, :to_date, :pending_only)
       end
   end
 end

--- a/app/models/audits1984/filtered_sessions.rb
+++ b/app/models/audits1984/filtered_sessions.rb
@@ -6,6 +6,7 @@ module Audits1984
     attribute :from_date, :date
     attribute :to_date, :date
     attribute :sensitive_only, :boolean
+    attribute :pending_only, :boolean
 
     def self.resume(attributes)
       new attributes&.with_indifferent_access&.slice(*attribute_names)
@@ -18,6 +19,7 @@ module Audits1984
     def all
       sessions = Console1984::Session.order(created_at: :desc, id: :desc)
       sessions = sessions.sensitive if sensitive_only
+      sessions = sessions.pending if pending_only
       sessions = sessions.where("console1984_sessions.created_at >= ?", from_date.beginning_of_day) if from_date.present?
       sessions = sessions.where("console1984_sessions.created_at <= ?", to_date.end_of_day) if to_date.present?
       sessions

--- a/app/views/audits1984/sessions/_filter.html.erb
+++ b/app/views/audits1984/sessions/_filter.html.erb
@@ -24,6 +24,13 @@
         </div>
       </div>
 
+      <div class="field">
+        <div class="control">
+          <%= form.label :sensitive_only, "Pending review only", class: "checkbox" %>
+          <%= form.check_box :pending_only %>
+        </div>
+      </div>
+
       <div class="field is-grouped">
         <div class="control">
           <%= form.submit "Filter", class: "button is-link" %>

--- a/app/views/audits1984/sessions/_filter.html.erb
+++ b/app/views/audits1984/sessions/_filter.html.erb
@@ -17,14 +17,12 @@
         </div>
       </div>
 
-      <div class="field">
+      <div class="field is-grouped">
         <div class="control">
           <%= form.label :sensitive_only, "Only with sensitive access", class: "checkbox" %>
           <%= form.check_box :sensitive_only %>
         </div>
-      </div>
-
-      <div class="field">
+      
         <div class="control">
           <%= form.label :sensitive_only, "Pending review only", class: "checkbox" %>
           <%= form.check_box :pending_only %>

--- a/test/models/audits1984/filtered_sessions_test.rb
+++ b/test/models/audits1984/filtered_sessions_test.rb
@@ -32,11 +32,23 @@ class Audits1984::FilteredSessionsTest < ActiveSupport::TestCase
     assert_equal second, filtered_sessions.pending_session_after(first)
   end
 
+  test "filter pending sessiosn" do
+    audited_session = console1984_sessions(:sensitive_printing)
+    auditor = ::Auditor.create!(name: "Jorge")
+    audited_session.audits.create!(status: "approved", auditor_id: auditor.id)
+    pending_session = console1984_sessions(:arithmetic)
+
+    assert_filtered_sessions \
+      included: pending_session,
+      excluded: audited_session,
+      pending: true
+  end
+
   private
-    def assert_filtered_sessions(included: [], excluded: [], sensitive: false, from: nil, to: nil)
+    def assert_filtered_sessions(included: [], excluded: [], sensitive: false, from: nil, to: nil, pending: false)
       assert included.present? || excluded.present?, "Not really testing anything?"
 
-      filtered_sessions = Audits1984::FilteredSessions.new(sensitive_only: sensitive, from_date: from, to_date: to)
+      filtered_sessions = Audits1984::FilteredSessions.new(sensitive_only: sensitive, from_date: from, to_date: to, pending_only: pending)
 
       Array(included).each do |expected_session|
         assert_includes filtered_sessions.all, expected_session


### PR DESCRIPTION
Add a checkbox to filter only to pending sessions which still require an audit.  We have a monthly calendar entry to review console sessions - but we may miss some or have ones we need to double check which aren't reviewed at the time.  

![image](https://github.com/user-attachments/assets/70ceaa5e-e884-4641-9849-c18df9227209)
