### PR TITLE
add a fix for "undefined method `assets'" based on comments in #50

### DIFF
--- a/lib/audits1984/engine.rb
+++ b/lib/audits1984/engine.rb
@@ -20,7 +20,31 @@ module Audits1984
     end
 
     initializer "audits1984.assets.precompile" do |app|
-      app.config.assets.precompile << "audits1984_manifest.js"
+      if app.config.respond_to?(:assets)
+        app.config.assets.precompile << "audits1984_manifest.js"
+      else
+        gem_asset_root = Audits1984::Engine.root.join("app/assets")
+        tmp_asset_root = Rails.root.join("tmp/audits1984/assets")
+
+        # Create audits1984 css and js files
+        asset_files = [
+          "javascripts/audits1984/application.js",
+          "stylesheets/audits1984/bulma.min.css",
+          "stylesheets/audits1984/application.css",
+        ]
+
+        asset_files.each do |file|
+          unless (local_file = tmp_asset_root.join(file)).exist?
+            local_file.dirname.mkpath
+            local_file.write gem_asset_root.join(File.dirname(file)).children.map(&:read).join("\n\n")
+          end
+        end
+
+        # Serve custom assets instead of audits1984's (that will 404 without the asset pipeline)
+        Rails.application.config.middleware.use Rack::Static,
+          urls: %w[/javascripts/audits1984 /stylesheets/audits1984 /images/audits1984],
+          root: tmp_asset_root
+      end
     end
   end
 end


### PR DESCRIPTION
This incorporates the patches suggested in #50 as-is.

I'd rather have this in the gem than use our fork, especially in the medium to long term.