### PR TITLE
Fix session datetime always being :09 minutes: it's using the month `%m` in the minutes position

### DIFF
--- a/app/helpers/audits1984/application_helper.rb
+++ b/app/helpers/audits1984/application_helper.rb
@@ -18,7 +18,7 @@ module Audits1984
 
     def format_date_and_time(date)
       # <time datetime="2016-1-1">11:09 PM - 1 Jan 2016</time>
-      date.strftime("%Y-%m-%d at %I:%m %P")
+      date.strftime("%Y-%m-%d at %I:%M %P")
     end
 
     def highlighted_code_from(commands)


### PR DESCRIPTION
`%m` is the month; `%M` is the minutes.

<img width="1212" height="83" alt="image" src="https://github.com/user-attachments/assets/d643937e-3a77-4848-ada0-8c04c47741a3" />

<img width="361" height="154" alt="image" src="https://github.com/user-attachments/assets/e115bf5f-b6e9-45b7-acd6-506aab3ed99d" />

```
$ irb
irb(main):001> Time.now
=> 2025-09-26 12:33:28.310967 +0100
irb(main):002> Time.now.strftime("%Y-%m-%d at %I:%m %P")
=> "2025-09-26 at 12:09 pm"
irb(main):003> Time.now.strftime("%Y-%m-%d at %I:%M %P")
=> "2025-09-26 at 12:33 pm"
irb(main):004> RUBY_ENGINE
=> "ruby"
irb(main):005> RUBY_ENGINE_VERSION
=> "3.4.5"
```