### PR TITLE
ci: harden GitHub Actions workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
     continue-on-error: ${{ matrix.rails-version == 'rails_edge' }}
     services:
       postgres:
-        image: postgres:16 # zizmor: ignore[unpinned-images] -- version tag pins to a specific release
+        image: postgres:16 # zizmor: ignore[unpinned-images] -- version tag is fine for service containers
         env:
           POSTGRES_HOST_AUTH_METHOD: "trust"
         options: >-
@@ -68,7 +68,7 @@ jobs:
         ports:
           - 55433:5432
       mysql:
-        image: mysql:8.0 # zizmor: ignore[unpinned-images] -- version tag pins to a specific release
+        image: mysql:8.0 # zizmor: ignore[unpinned-images] -- version tag is fine for service containers
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
         options: >-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,13 +5,19 @@ on:
   pull_request:
     types: [ opened, synchronize ]
 
+permissions: {}
+
 jobs:
   rubocop:
     name: Rubocop
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - name: Setup Ruby and install gems
         uses: ruby/setup-ruby@319994f95fa847cf3fb3cd3dbe89f6dcde9f178f # v1.295.0
         with:
@@ -23,6 +29,8 @@ jobs:
   tests:
     name: Ruby ${{ matrix.ruby-version }}, ${{ matrix.rails-version }}, ${{ matrix.database }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -59,6 +67,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - name: Setup Ruby and install gems
         uses: ruby/setup-ruby@319994f95fa847cf3fb3cd3dbe89f6dcde9f178f # v1.295.0
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,23 @@ jobs:
       - name: Run rubocop
         run: |
           bundle exec rubocop --parallel
+  lint-actions:
+    name: GitHub Actions audit
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run actionlint
+        uses: rhysd/actionlint@393031adb9afb225ee52ae2ccd7a5af5525e03e8 # v1.7.11
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2
+        with:
+          advanced-security: false
   tests:
     name: Ruby ${{ matrix.ruby-version }}, ${{ matrix.rails-version }}, ${{ matrix.database }}
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
     continue-on-error: ${{ matrix.rails-version == 'rails_edge' }}
     services:
       postgres:
-        image: postgres:16
+        image: postgres:16 # zizmor: ignore[unpinned-images] -- version tag pins to a specific release
         env:
           POSTGRES_HOST_AUTH_METHOD: "trust"
         options: >-
@@ -51,7 +51,7 @@ jobs:
         ports:
           - 55433:5432
       mysql:
-        image: mysql:8.0
+        image: mysql:8.0 # zizmor: ignore[unpinned-images] -- version tag pins to a specific release
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
         options: >-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Setup Ruby and install gems
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@319994f95fa847cf3fb3cd3dbe89f6dcde9f178f # v1.295.0
         with:
           ruby-version: '4.0'
           bundler-cache: true
@@ -58,9 +58,9 @@ jobs:
       TARGET_DB: ${{ matrix.database }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Setup Ruby and install gems
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@319994f95fa847cf3fb3cd3dbe89f6dcde9f178f # v1.295.0
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true


### PR DESCRIPTION
## Summary
- Pin all actions to SHA hashes via `pinact`
- Fix `artipacked` and `excessive-permissions` findings
- Suppress `unpinned-images` for postgres and mysql service containers
- Add `lint-actions` CI job (actionlint + zizmor)
- Add dependabot config for weekly batched github-actions updates

## Test plan
- [ ] CI passes (lint-actions job runs clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)