### PR TITLE
Remove calls to `required_dependency`

### DIFF
--- a/app/controllers/audits1984/audits_controller.rb
+++ b/app/controllers/audits1984/audits_controller.rb
@@ -1,5 +1,3 @@
-require_dependency "audits1984/application_controller"
-
 module Audits1984
   class AuditsController < ApplicationController
     include FilteredSessionsScoped

--- a/app/controllers/audits1984/filtered_sessions_controller.rb
+++ b/app/controllers/audits1984/filtered_sessions_controller.rb
@@ -1,5 +1,3 @@
-require_dependency "audits1984/application_controller"
-
 module Audits1984
   class FilteredSessionsController < ApplicationController
     def update

--- a/app/controllers/audits1984/sessions_controller.rb
+++ b/app/controllers/audits1984/sessions_controller.rb
@@ -1,5 +1,3 @@
-require_dependency "audits1984/application_controller"
-
 module Audits1984
   class SessionsController < ApplicationController
     include FilteredSessionsScoped


### PR DESCRIPTION
which is deprecated in edge Rails and will be removed in Rails 9

These calls are unnecessary for modern Rails apps that use Zeitwerk.